### PR TITLE
Import downstream memory region changes

### DIFF
--- a/hw/arm/apple-m1.c
+++ b/hw/arm/apple-m1.c
@@ -142,7 +142,7 @@ static uint64_t m1_pmgr_read(void *opaque, hwaddr offset, unsigned size)
         return extract64(rvbar, (offset & 4) ? 32 : 0, 32);
     }   
     default:
-        qemu_log_mask(LOG_UNIMP, "M1 PMGR: Unhandled read of @ %#lx\n", offset);
+        qemu_log_mask(LOG_UNIMP, "M1 PMGR: Unhandled read of @ %#"PRIx64"\n", offset);
         break;
     }
     return 0;
@@ -200,7 +200,7 @@ static void m1_pmgr_write(void *opaque, hwaddr offset, uint64_t val, unsigned si
         break;
     }
     default:
-        qemu_log_mask(LOG_UNIMP, "M1 PMGR: Unhandled write of %#x to %#lx\n", value, offset);
+        qemu_log_mask(LOG_UNIMP, "M1 PMGR: Unhandled write of %#x to %#" PRIx64 "\n", value, offset);
         break;
     }
 }
@@ -525,7 +525,7 @@ static void create_apple_dt(MachineState *machine) {
                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
                0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0};
     bufsize = sizeof(databuf);
-    printf("Mapping device tree at: %lx\n", memmap[M1_ROM].base);
+    printf("Mapping device tree at: %" PRIx64 "\n", memmap[M1_ROM].base);
     rom_add_blob_fixed("device-tree", databuf, bufsize, memmap[M1_ROM].base);
     //g_free(databuf);
     // XXX: Make this use the actual size?
@@ -591,7 +591,7 @@ static void create_boot_args(MachineState *machine) {
     memcpy(bootargs.cmdline, buf, sizeof(buf)); // FIXME: This is stupid
     bootargs.cmdline[sizeof(buf)] = 0x0;
 
-    printf("Mapping boot args tree at: %lx\n", device_tree_end);
+    printf("Mapping boot args tree at: %" PRIx64 "\n", device_tree_end);
     rom_add_blob_fixed("boot-args", &bootargs, sizeof(bootargs), device_tree_end);
 }
 
@@ -686,7 +686,7 @@ static void m1_mac_init(MachineState *machine)
             error_report("Failed to load firmware from %s", machine->firmware);
             exit(1);
         }
-        printf("Firmware loaded@%0lx size=%0x\n", safe_ram_start, load_size);
+        printf("Firmware loaded@%0" PRIx64 " size=%0x\n", safe_ram_start, load_size);
         safe_ram_start += load_size;
     }
     
@@ -701,7 +701,7 @@ static void m1_mac_init(MachineState *machine)
             error_report("Failed to load kernel from %s", machine->kernel_filename);
             exit(1);
         }
-        printf("Kernel loaded@%0lx size=%0x\n", kernel_base, kernel_size);
+        printf("Kernel loaded@%0" PRIx64 " size=%0x\n", kernel_base, kernel_size);
         safe_ram_start += kernel_size;
     }
     
@@ -714,7 +714,7 @@ static void m1_mac_init(MachineState *machine)
             error_report("Failed to load dtb from %s", machine->dtb);
             exit(1);
         }
-        printf("DTB loaded@%0lx size=%0x\n", dtb_base, dtb_size);
+        printf("DTB loaded@%0" PRIx64 " size=%0x\n", dtb_base, dtb_size);
         safe_ram_start += dtb_size;
     }
     
@@ -729,20 +729,20 @@ static void m1_mac_init(MachineState *machine)
             error_report("Failed to load initrd from %s", machine->initrd_filename);
             exit(1);
         }
-        printf("Initrd loaded@%0lx size=%0x\n", initrd_base, initrd_size);
+        printf("Initrd loaded@%0" PRIx64 " size=%0x\n", initrd_base, initrd_size);
         safe_ram_start += initrd_size;
     }
     /* TODO: do this in a better way or not at all it's helpful for dev tho */
     FILE *fconfig = fopen("boot_params.config", "w");
     if (fconfig != NULL) {
         if (kernel_base) {
-            fprintf(fconfig, "kernel\t0x%lx\t0x%x\n", kernel_base, kernel_size);
+            fprintf(fconfig, "kernel\t0x%" PRIx64 "\t0x%x\n", kernel_base, kernel_size);
         }
         if (dtb_base) {
-            fprintf(fconfig, "dtb\t0x%lx\t0x%x\n", dtb_base, dtb_size);
+            fprintf(fconfig, "dtb\t0x%" PRIx64 "\t0x%x\n", dtb_base, dtb_size);
         }
         if (initrd_base) {
-            fprintf(fconfig, "initrd\t0x%lx\t0x%x\n", initrd_base, initrd_size);
+            fprintf(fconfig, "initrd\t0x%" PRIx64 "\t0x%x\n", initrd_base, initrd_size);
         }
         fclose(fconfig);
     }

--- a/hw/intc/apple-aic.c
+++ b/hw/intc/apple-aic.c
@@ -521,7 +521,7 @@ static uint64_t aic_mem_read(void *opaque, hwaddr offset, unsigned size)
         /* TODO: this is bad and broken, we need per-cpu state to do this */
         return (aic_emulate_timer(ARM_CPU(cpu)) >> 32) & 0xFFFFFFFF;
     default:
-        printf("aic_mem_read: Unhandled read from @%0lx of size=%d\n",
+        printf("aic_mem_read: Unhandled read from @%0" PRIx64 " of size=%d\n",
                offset, size);
     }
     return 0;
@@ -595,8 +595,8 @@ static void aic_mem_write(void *opaque, hwaddr offset, uint64_t val,
         aic_update_irq(s);
         break;
     default:
-        printf("aic_mem_write: Unhandled write of %0lx to @%0lx of size=%d\n",
-               val, offset, size);
+        printf("aic_mem_write: Unhandled write of %0" PRIx64 " to @%0" PRIx64 " of "
+               "size=%d\n", val, offset, size);
     }
 }
 

--- a/include/hw/arm/apple-m1.h
+++ b/include/hw/arm/apple-m1.h
@@ -25,6 +25,13 @@
 
 OBJECT_DECLARE_SIMPLE_TYPE(AppleM1State, APPLE_M1)
 
+// A RAM memory region that is reloaded from static data on reset
+struct m1_rel_region {
+    MemoryRegion region;
+    void* data;
+};
+
+
 struct AppleM1State {
     /*< private >*/
     DeviceState parent_obj;
@@ -46,8 +53,14 @@ struct AppleM1State {
     AppleAICState aic;
     
     /* SoC memory regions */
-    /* FIXME every region created in the .c file needs to move here */
-    MemoryRegion vram_mr;
+    struct m1_rel_region ram_adt_mr;
+    struct m1_rel_region ram_firmware_mr;
+    struct m1_rel_region ram_kernel_mr;
+    struct m1_rel_region ram_initrd_mr;
+    struct m1_rel_region ram_dtb_mr;
+    struct m1_rel_region ram_bootargs_mr;
+    MemoryRegion ram_free_mr;
+    MemoryRegion ram_vram_mr;
 };
 
 #endif // HW_ARM_APPLE_M1_H


### PR DESCRIPTION
These downstream changes implement TODO items that I mostly put off for future cleanup since at the time not much was known about the M1's memory layout proper, more is known now and @VinDuv has helpfully already implemented them.