### PR TITLE
M1 init cleanups

### DIFF
--- a/hw/arm/apple-m1.c
+++ b/hw/arm/apple-m1.c
@@ -736,7 +736,7 @@ static void m1_mac_init(MachineState *machine)
         }
     	// HACK: Total hack to hardcode entry offset of m1n1 for post reset
         m1->entry_addr = offset - result + 0x4800;
-        printf("Entry addr computed was: 0x%llx\n", m1->entry_addr);
+        printf("Entry addr computed was: 0x%" HWADDR_PRIx "\n", m1->entry_addr);
         remaining_mem -= result;
     }
     

--- a/include/hw/arm/apple-m1.h
+++ b/include/hw/arm/apple-m1.h
@@ -37,7 +37,8 @@ struct AppleM1State {
     /* Cores */
     /* Icestorm  0..num_icestorm-1 */
     /* Firestorm num_icestorm..num_firestorm-1 */
-    /* TODO Replace this with the proper concept of core clusters */
+    /* TODO: Replace this with the proper concept of core clusters */
+    /* FIXME: These will definitely need Apple specific sub-cpu types */
     ARMCPU icestorm_cores[APPLE_M1_ICESTORM_CPUS];
     ARMCPU firestorm_cores[APPLE_M1_FIRESTORM_CPUS];
 
@@ -46,8 +47,22 @@ struct AppleM1State {
     AppleAICState aic;
     
     /* SoC memory regions */
-    /* FIXME every region created in the .c file needs to move here */
-    MemoryRegion vram_mr;
+    /* TODO: VRAM is actually a part of system RAM but we need to tell the FB code
+     * about where it is somehow, so do that later
+     */
+    MemoryRegion ram_vram_mr;
+    /* I think this is a hack */
+    MemoryRegion ram_vram_alias;
+    
+    /* 
+     * This is used by the reset logic to figure out where to go during reset
+     * technically this is the RVBAR for icestorm core 0 and can probably be
+     * handled directly later
+     */
+    hwaddr boot_args_base;
+
+    /* XXX: This maybe better if renamed to "reset_addr" */
+    hwaddr entry_addr;
 };
 
 #endif // HW_ARM_APPLE_M1_H

--- a/include/hw/arm/apple-m1.h
+++ b/include/hw/arm/apple-m1.h
@@ -51,8 +51,6 @@ struct AppleM1State {
      * about where it is somehow, so do that later
      */
     MemoryRegion ram_vram_mr;
-    /* I think this is a hack */
-    MemoryRegion ram_vram_alias;
     
     /* 
      * This is used by the reset logic to figure out where to go during reset


### PR DESCRIPTION
@VinDuv Alright that took longer than I expected but I was able to refactor the code significantly. It's still not entirely complete because I expect that a desirable change will be having the helper functions for loading provide an output argument to provide the aligned base addresses they end up using.

But I've tested that it compiles and seems to do what's expected. There's a little weird hack for the framebuffer that I need to test separately (it might not need the hack, it might need a different hack and not work at all, the info QEMU can give me isn't detailed enough to tell me without testing it on a system with gui support)